### PR TITLE
Add LM Studio endpoint and propose MIT license

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# AGENTS.md
+
+## Project Identity
+
+This repository is a translator extension for **XUnity.AutoTranslator**, the Unity game auto-translation plugin.
+
+It is not a standalone Unity project. Treat it as a .NET plugin that adds LLM-backed translator endpoints to XUnity.AutoTranslator, with **LM Studio support as a first-class added extension**.
+
+The main runtime goal is:
+
+- Load inside XUnity.AutoTranslator's `Translators` folder.
+- Register translator endpoints such as `OpenAiTranslate`, `OllamaTranslate`, and `LmStudioTranslate`.
+- Let games using XUnity.AutoTranslator translate text through local or hosted chat-completion APIs.
+
+## Important Context
+
+- `LmStudioTranslatorEndpoint.cs` implements the LM Studio endpoint.
+- LM Studio uses an OpenAI-compatible chat-completion API, normally:
+  `http://localhost:1234/v1/chat/completions`
+- The service ID for LM Studio is `LmStudioTranslate`.
+- Sample LM Studio configuration lives in:
+  `XUnity.AutoTranslator.LlmTranslators/SampleConfig/LmStudio.yaml`
+- XUnity.AutoTranslator configuration selects the endpoint through:
+
+```ini
+[Service]
+Endpoint=LmStudioTranslate
+FallbackEndpoint=
+```
+
+## Repository Layout
+
+```text
+XUnity.AutoTranslator.LlmTranslators/
+  OpenAiTranslatorEndpoint.cs
+  OllamaTranslatorEndpoint.cs
+  LmStudioTranslatorEndpoint.cs
+  Behavior/
+  Config/
+  SampleConfig/
+
+XUnity.AutoTranslator.LlmTranslators.Tests/
+  BehaviorTests.cs
+  ConfigTests.cs
+  PromptTests.cs
+
+libs/
+  XUnity.AutoTranslator reference assemblies used for compilation
+```
+
+## Development Rules
+
+- Preserve compatibility with Unity/XUnity.AutoTranslator environments.
+- Keep the plugin target framework at `net45` unless there is an explicit compatibility decision.
+- Do not convert this into a Unity project layout.
+- Do not remove the local-reference assemblies in `libs/`; they are build references for XUnity.AutoTranslator APIs.
+- Keep endpoint IDs stable because users reference them from `Config.ini`.
+- Keep LM Studio local-server defaults friendly to offline/local model workflows.
+- Avoid committing real API keys or per-user override files.
+
+## Configuration Model
+
+Each endpoint is driven by YAML files in the AutoTranslator config folder:
+
+- `OpenAi.yaml`
+- `Ollama.yaml`
+- `LmStudio.yaml`
+
+Override files can replace YAML values:
+
+- `*-SystemPrompt.txt`
+- `*-GlossaryPrompt.txt`
+- `*-ApiKey.txt`
+
+Glossary files use endpoint-specific names, for example:
+
+- `LmStudio-Glossary.yaml`
+
+## Build
+
+```bash
+dotnet build XUnity.AutoTranslate.LlmTranslators.sln -c Release
+```
+
+Release builds copy the translator DLL and sample configs into the repository `Release` folder. The project also supports optional game-directory deployment through `DeployToGameDirs=true`; do not enable it by default.
+
+## Tests
+
+Run the non-live test suite with:
+
+```bash
+dotnet test XUnity.AutoTranslate.LlmTranslators.sln -c Release --no-build --filter "FullyQualifiedName!~PromptTests"
+```
+
+`PromptTests` may call live OpenAI, Ollama, or LM Studio endpoints, so do not assume they are safe for ordinary CI or offline runs.
+
+## Common Change Guidance
+
+When changing LM Studio behavior:
+
+- Check parity with the shared behavior in `Behavior/BaseEndpointBehavior.cs`.
+- Keep request payloads OpenAI-chat-completion compatible unless the change is explicitly LM Studio-specific.
+- Keep `apiKeyRequired: false` as the expected local LM Studio default.
+- Validate response extraction against the `choices[0].message.content` shape.
+
+When changing prompt or glossary behavior:
+
+- Prefer shared logic in `Config/` or `Behavior/`.
+- Keep sample config files usable as copy-paste starting points for game users.
+- Preserve formatting-sensitive game text such as tags, escaped characters, and line breaks.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 joshfreitas1984 and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,79 +1,129 @@
-﻿# XUnity.AutoTranslator.LlmTranslators
+# XUnity.AutoTranslator.LlmTranslators
 
-A series of LLM Translators that can be used with popular LLMs such as ChatGpt configured with prompts to translate games with XUnity.AutoTranslator. 
+LLM-backed translator endpoints for [XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator).
 
-Current supported plugins include:
-- [OpenAI](https://platform.openai.com/)
-	- Probably the most popular LLM that has the highest quality but is not Free
-- [Ollama Models](https://ollama.com/)
-	- Ollama is a local hosting option for LLMs. You are able to run one or more llms on your local machine of varying size. This option is free but will require you to engineer your prompts dependant on the model and/or language.
+This plugin adds OpenAI-compatible and Ollama chat-completion translators for games that use XUnity.AutoTranslator. It is designed for prompt-driven game translation, glossary-assisted terminology control, and higher request concurrency than the built-in `Custom` endpoint.
 
-# Why use this instead of the [Custom] endpoint?
+## Supported Endpoints
 
-- We run up to 15 translations in parallel (unlike the custom endpoint which is tied to 1)
-- We have removed the spam restriction (which has 1 second by default on custom)
+| Endpoint | Service ID | Use case |
+| --- | --- | --- |
+| OpenAI | `OpenAiTranslate` | Hosted OpenAI chat-completion models such as `gpt-4o-mini`. |
+| Ollama | `OllamaTranslate` | Local Ollama models served from `http://localhost:11434/api/chat` or another compatible URL. |
 
-# Installation instructions
+## Why Use This Instead Of `Custom`
 
-1. Download or Build the latest assembly from the Releases
-2. Install [XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator) into your game as normal with either ReiPatcher or BepinEx
-3. Place assembly into Translators folder for your game, you should see the other translators in the folder (eg. CustomTranslate.dll)
-	- If used ReiPatcher: `<GameDir>/<Game name>_ManagedData/Translators` 
-	- If used BepinEx: `<GameDir>/BepinEx/plugins/XUnity.AutoTranslator/Translators` 
+- Runs multiple translations in parallel.
+- Removes the default spam restriction used by `Custom`.
+- Keeps LLM prompts, model parameters, API keys, and glossary data in YAML/text files that can be reused across games.
+- Supports per-game override files for prompts, glossary prompts, and API keys.
 
-# Configuration
+## Repository Layout
 
-We use an additional yaml configuration file to make it easier to copy around with multiple games. We also support configuration override files which take precedence over the main file. This is so things like copying and pasting prompts and glossary items becomes easier while in game. It also means we do not mess with the standard Autotranslator INI file.
+```text
+XUnity.AutoTranslator.LlmTranslators/
+  OpenAiTranslatorEndpoint.cs       OpenAI endpoint implementation
+  OllamaTranslatorEndpoint.cs       Ollama endpoint implementation
+  Behavior/                         Shared request and response handling
+  Config/                           YAML configuration and glossary models
+  SampleConfig/                     Example OpenAI/Ollama config files
+XUnity.AutoTranslator.LlmTranslators.Tests/
+  BehaviorTests.cs                  Cleanup and request behavior tests
+  ConfigTests.cs                    Configuration loading tests
+  PromptTests.cs                    Prompt evaluation helpers
+libs/                               XUnity.AutoTranslator reference assemblies
+```
 
-To configure your LLM you will need to follow the following steps:
+## Installation
 
-1. Either run the game to create the default config or copy the [Sample Configs](./XUnity.AutoTranslator.LlmTranslators/SampleConfig) into the AutoTranslator folder
-	- If used ReiPatcher: `<GameDir>/AutoTranslator`
-	- If used BepinEx: `<GameDir>/BepinEx/config`
-2. Open the config for the LLMTranslator you wish to use
-	- If OpenaI: `OpenAi.Yml`
-	- If a local Olama LLM: `Ollama.Yml`
-3. Update your config with any API keys, custom urls, glossaries and system prompts.
-4. Finally update your AutoTranslator INI file with your translate service
-	- ```
-	  [Service]
-	  Endpoint=OpenAiTranslate
-	  FallbackEndpoint=
-	  ```
-	- If OpenAi: `OpenAiTranslate`
-	- If a local Olama LLM: `OllamaTranslate`
+1. Download a release build or build the project locally.
+2. Install XUnity.AutoTranslator into your game with ReiPatcher or BepInEx.
+3. Copy `XUnity.AutoTranslator.LlmTranslators.dll` into the game's `Translators` folder:
+   - ReiPatcher: `<GameDir>/<GameName>_ManagedData/Translators`
+   - BepInEx: `<GameDir>/BepInEx/plugins/XUnity.AutoTranslator/Translators`
+4. Copy the sample config files from `XUnity.AutoTranslator.LlmTranslators/SampleConfig` into the AutoTranslator config folder:
+   - ReiPatcher: `<GameDir>/AutoTranslator`
+   - BepInEx: `<GameDir>/BepInEx/config`
+5. Edit the AutoTranslator INI file and select the endpoint:
 
-## Global API Key
+```ini
+[Service]
+Endpoint=OpenAiTranslate
+FallbackEndpoint=
+```
 
-We also use global environment variables so you can just set your API Key once and never have to think about it again.
+Use `OllamaTranslate` instead of `OpenAiTranslate` when using Ollama.
 
-1. Google how to set environment variables on your operating system
-2. Set the following environment variable: `AutoTranslator_API_Key` to the value of your API Key.
+## Configuration
 
-## Configuration Override Files
+Each endpoint uses a YAML file in the AutoTranslator config folder:
 
-We have seperate files that can be override any config you have loaded in your config file. This makes it easier to publish game specific prompts, glossaries or just make it easier to use multi line prompts without having to worry about YAML formatting.
+- `OpenAi.yaml`
+- `Ollama.yaml`
 
-These files are:
-  - `OpenAi-SystemPrompt.txt` or `Ollama-SystemPrompt.txt`
-	- Use this file to update your system prompt
-  - `OpenAi-GlossaryPrompt.txt` or `Ollama-GlossaryPrompt.txt`
-	- Use this file to update your glossary prompt
-  - `OpenAi-ApiKey.txt` or `Ollama-ApiKey.txt`
-	- Use this file to update your API Key
+Important fields:
 
-# Glossary
+| Field | Description |
+| --- | --- |
+| `apiKey` | API key used for `Authorization: Bearer ...`. |
+| `apiKeyRequired` | Set `false` for local services that do not require an API key. |
+| `url` | Chat-completion endpoint URL. |
+| `model` | Model name sent in the request payload. |
+| `modelParams` | Additional model parameters such as `temperature`, `top_p`, or Ollama-specific values. |
+| `systemPrompt` | Main translation instruction sent as the system message. |
+| `glossaryPrompt` | Instruction prepended before matching glossary terms. |
 
-The glossary feature scans for text that matches entries in the glossary and allows you to instruct how the LLM will translate that word/term/sentence. This reduces hallucinations and mistranslations significantly. The format for a glossary is as follows:
+Example OpenAI configuration:
+
+```yaml
+apiKey: "Change me"
+apiKeyRequired: true
+url: "https://api.openai.com/v1/chat/completions"
+model: "gpt-4o-mini"
+modelParams:
+  temperature: 0.2
+  top_p: 0.9
+systemPrompt: |
+  Translate Simplified Chinese into English. Output only the translation.
+glossaryPrompt: |
+  # Glossary for Consistent Translations
+  Use the translation for exact matches.
+  ## Terms
+```
+
+## API Key Options
+
+You can set an API key in either location:
+
+- In the endpoint YAML file through `apiKey`.
+- In an override file named `OpenAi-ApiKey.txt` or `Ollama-ApiKey.txt`.
+
+Keep API key override files out of source control.
+
+## Override Files
+
+Override files live next to the endpoint YAML file and take precedence over YAML values:
+
+| File | Purpose |
+| --- | --- |
+| `OpenAi-SystemPrompt.txt` / `Ollama-SystemPrompt.txt` | Replaces the configured system prompt. |
+| `OpenAi-GlossaryPrompt.txt` / `Ollama-GlossaryPrompt.txt` | Replaces the configured glossary prompt. |
+| `OpenAi-ApiKey.txt` / `Ollama-ApiKey.txt` | Replaces the configured API key. |
+
+These files are useful when maintaining per-game prompts without editing the main YAML file.
+
+## Glossary
+
+Glossary YAML files are named `OpenAi-Glossary.yaml` or `Ollama-Glossary.yaml`. Matching `raw` terms are appended to the prompt for the current source string.
+
+Minimum entry:
 
 ```yaml
 - raw: 舅舅
   result: Uncle
 ```
 
-This is the minimum required for an entry in a glossary. You can also specifically give a seperate glossary prompt to guide your LLM better.
-
-The glossary format supports more options that are mostly there to help translation teams produce more consistent Autotranslator glossaries. The full list is as follows:
+Full entry format:
 
 ```yaml
 - raw: 舅舅
@@ -84,18 +134,52 @@ The glossary format supports more options that are mostly there to help translat
   checkForMistranslation: true
 ```
 
-Please note `transliteration`, `context` do nothing in the plugin.
-Currently `checkForHallucination` and `checkForMistranslation` have not been implemented - stay tuned.
+`transliteration` and `context` are documentation fields for translators. `checkForHallucination` and `checkForMistranslation` are reserved for future validation behavior.
 
-# Fine tuning your prompt
+## Prompt Tuning
 
-Please note the prompt is what actually tells ChatGPT what to translate. Some things that will help:
-- Update the languages eg. Simplified Chinese to English, Japanese to English
-- Ensure you add context to the prompt for the game such as 'Wuxia', 'Sengoku Jidai', 'Xanxia', 'Eroge'. 
-- Make sure you tell it how to translate names whether you want literal translation or keep the original names
+Good results depend heavily on the prompt and model. For game translation, include:
 
-A test project is included with the project. The [PromptTests](./XUnity.AutoTranslator.LlmTranslators.Tests/PromptTests.cs) will let you easily change your prompt based on your model and compare outputs to some ChatGPT4o pretranslated values. These are a good baseline to compare your prompts or other models to, most cases will show you where the model will lose the plot and hallucinate.
+- Source and target languages.
+- Tone and genre context such as wuxia, eroge, fantasy, or historical drama.
+- Name handling rules, including whether to keep names, use romanization, or translate titles.
+- Formatting rules, especially for escaped characters, tags, and line breaks.
+- A short "output only the translation" instruction.
 
-# Packages
+The test project includes `PromptTests` that can be used to compare prompt outputs against example translations.
 
-The assemblies included are the Dev versions of XUnity.AutoTranslator. Feel free to star/fork this repo however you like.
+## Build And Test
+
+Prerequisites:
+
+- .NET SDK that can build the solution.
+- XUnity.AutoTranslator reference assemblies in `libs/`.
+
+Build:
+
+```powershell
+dotnet build XUnity.AutoTranslate.LlmTranslators.sln -c Release
+```
+
+Run tests:
+
+```powershell
+dotnet test XUnity.AutoTranslate.LlmTranslators.sln
+```
+
+Some prompt tests are environment-dependent. They expect local prompt fixture files and, for Ollama coverage, a running Ollama server on the configured URL.
+
+Release builds merge `YamlDotNet.dll` into the translator assembly through `ILRepack.MSBuild.Task`.
+
+## Current Project Notes
+
+- The plugin target framework is `net45` for compatibility with Unity/XUnity.AutoTranslator environments.
+- The test project currently targets `net9.0`; install a matching SDK/runtime or retarget the tests if your machine only has another .NET SDK.
+- Some tests are integration-style prompt checks, not isolated unit tests. They can fail when `TestOutput` fixtures are missing or Ollama is not running.
+- Release builds currently contain local post-build copy paths in the project file. Adjust or remove those paths before using the project in a different environment.
+- On newer .NET SDKs, the release `ILRepack` step may require package/tooling updates if it fails during assembly merging.
+- The included `libs/` assemblies are XUnity.AutoTranslator development references used for compilation.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Current supported plugins include:
 	- Probably the most popular LLM that has the highest quality but is not Free
 - [Ollama Models](https://ollama.com/)
 	- Ollama is a local hosting option for LLMs. You are able to run one or more llms on your local machine of varying size. This option is free but will require you to engineer your prompts dependant on the model and/or language.
+- [LM Studio](https://lmstudio.ai/)
+	- LM Studio is a local hosting option for OpenAI-compatible chat completion APIs. Start the local server in LM Studio and use the model id shown by LM Studio in `LmStudio.yaml`.
 
 # Why use this instead of the [Custom] endpoint?
 
@@ -33,6 +35,7 @@ To configure your LLM you will need to follow the following steps:
 2. Open the config for the LLMTranslator you wish to use
 	- If OpenaI: `OpenAi.Yml`
 	- If a local Olama LLM: `Ollama.Yml`
+	- If a local LM Studio LLM: `LmStudio.Yml`
 3. Update your config with any API keys, custom urls, glossaries and system prompts.
 4. Finally update your AutoTranslator INI file with your translate service
 	- ```
@@ -42,6 +45,7 @@ To configure your LLM you will need to follow the following steps:
 	  ```
 	- If OpenAi: `OpenAiTranslate`
 	- If a local Olama LLM: `OllamaTranslate`
+	- If a local LM Studio LLM: `LmStudioTranslate`
 
 ## Global API Key
 
@@ -55,11 +59,11 @@ We also use global environment variables so you can just set your API Key once a
 We have seperate files that can be override any config you have loaded in your config file. This makes it easier to publish game specific prompts, glossaries or just make it easier to use multi line prompts without having to worry about YAML formatting.
 
 These files are:
-  - `OpenAi-SystemPrompt.txt` or `Ollama-SystemPrompt.txt`
+  - `OpenAi-SystemPrompt.txt`, `Ollama-SystemPrompt.txt` or `LmStudio-SystemPrompt.txt`
 	- Use this file to update your system prompt
-  - `OpenAi-GlossaryPrompt.txt` or `Ollama-GlossaryPrompt.txt`
+  - `OpenAi-GlossaryPrompt.txt`, `Ollama-GlossaryPrompt.txt` or `LmStudio-GlossaryPrompt.txt`
 	- Use this file to update your glossary prompt
-  - `OpenAi-ApiKey.txt` or `Ollama-ApiKey.txt`
+  - `OpenAi-ApiKey.txt`, `Ollama-ApiKey.txt` or `LmStudio-ApiKey.txt`
 	- Use this file to update your API Key
 
 # Glossary

--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ To configure your LLM you will need to follow the following steps:
 	- If a local Olama LLM: `OllamaTranslate`
 	- If a local LM Studio LLM: `LmStudioTranslate`
 
+## LM Studio
+
+To use LM Studio, start the local server in LM Studio and load the model you want to use for translation. The default LM Studio OpenAI-compatible chat completion URL is:
+
+```yaml
+url: "http://localhost:1234/v1/chat/completions"
+```
+
+Copy `LmStudio.yaml` into your AutoTranslator config folder, then update the `model` value to the model identifier shown by LM Studio:
+
+```yaml
+apiKey: "None"
+apiKeyRequired: false
+url: "http://localhost:1234/v1/chat/completions"
+model: "model-identifier"
+```
+
+Finally, set the translator endpoint in `Config.ini`:
+
+```ini
+[Service]
+Endpoint=LmStudioTranslate
+FallbackEndpoint=
+```
+
 ## Global API Key
 
 We also use global environment variables so you can just set your API Key once and never have to think about it again.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ LLM-backed translator endpoints for [XUnity.AutoTranslator](https://github.com/b
 
 This plugin adds OpenAI-compatible, Ollama, and LM Studio chat-completion translators for games that use XUnity.AutoTranslator. It is designed for prompt-driven game translation, glossary-assisted terminology control, and higher request concurrency than the built-in `Custom` endpoint.
 
+한국어 빌드 및 YAML 작성 예시는 [docs/BUILD_AND_YAML_EXAMPLES.ko.md](docs/BUILD_AND_YAML_EXAMPLES.ko.md)를 참고하세요.
+
 ## Supported Endpoints
 
 | Endpoint | Service ID | Use case |

--- a/XUnity.AutoTranslator.LlmTranslators.Tests/ConfigTests.cs
+++ b/XUnity.AutoTranslator.LlmTranslators.Tests/ConfigTests.cs
@@ -14,4 +14,36 @@ public class ConfigTests
 
         Assert.True(config.SystemPrompt!.Split("\n").Length > 1);
     }
+
+    [Fact]
+    public void TestLmStudioConfig()
+    {
+        var config = Configuration.GetConfiguration($"{sampleDirectory}/LmStudio.yaml");
+
+        Assert.Equal("http://localhost:1234/v1/chat/completions", config.Url);
+        Assert.Equal("model-identifier", config.Model);
+        Assert.False(config.ApiKeyRequired);
+        Assert.True(config.SystemPrompt!.Split("\n").Length > 1);
+    }
+
+    [Fact]
+    public void TestGlossaryPromptOverride()
+    {
+        var config = new LlmConfig { SystemPrompt = "System prompt", GlossaryPrompt = "Glossary prompt" };
+        var file = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(file, "Override glossary prompt");
+
+            Configuration.LoadGlossaryPrompt(config, file);
+
+            Assert.Equal("System prompt", config.SystemPrompt);
+            Assert.Equal("Override glossary prompt", config.GlossaryPrompt);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
 }

--- a/XUnity.AutoTranslator.LlmTranslators.Tests/XUnity.AutoTranslator.LlmTranslators.Tests.csproj
+++ b/XUnity.AutoTranslator.LlmTranslators.Tests/XUnity.AutoTranslator.LlmTranslators.Tests.csproj
@@ -11,12 +11,15 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="YamlDotNet" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\XUnity.AutoTranslator.LlmTranslators\XUnity.AutoTranslator.LlmTranslators.csproj" />
+    <!-- Link shared source instead of ProjectReference to keep net9 tests warning-free while the plugin stays net45 for Unity. -->
+    <Compile Include="..\XUnity.AutoTranslator.LlmTranslators\Behavior\*.cs" Link="Behavior\%(Filename)%(Extension)" />
+    <Compile Include="..\XUnity.AutoTranslator.LlmTranslators\Config\*.cs" Link="Config\%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/XUnity.AutoTranslator.LlmTranslators/Config/Configuration.cs
+++ b/XUnity.AutoTranslator.LlmTranslators/Config/Configuration.cs
@@ -88,7 +88,7 @@ public static class Configuration
         if (!File.Exists(file))
             return;
 
-        config.SystemPrompt = File.ReadAllText(file, Encoding.UTF8);
+        config.GlossaryPrompt = File.ReadAllText(file, Encoding.UTF8);
     }
 
     public static void LoadApiKey(LlmConfig config, string file)

--- a/XUnity.AutoTranslator.LlmTranslators/ILRepack.targets
+++ b/XUnity.AutoTranslator.LlmTranslators/ILRepack.targets
@@ -1,0 +1,16 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="ILRepacker" AfterTargets="Build" Condition="$(Configuration) == 'Release'">
+		<ItemGroup>
+			<InputAssemblies Include="$(TargetPath)" />
+			<InputAssemblies Include="$(TargetDir)YamlDotNet.dll" />
+		</ItemGroup>
+
+		<Message Text="MERGING: YamlDotNet into $(TargetFileName)" Importance="High" />
+
+		<ILRepack
+			Internalize="true"
+			InputAssemblies="@(InputAssemblies)"
+			OutputFile="$(TargetPath)"
+			TargetKind="Dll" />
+	</Target>
+</Project>

--- a/XUnity.AutoTranslator.LlmTranslators/LmStudioTranslatorEndpoint.cs
+++ b/XUnity.AutoTranslator.LlmTranslators/LmStudioTranslatorEndpoint.cs
@@ -1,0 +1,59 @@
+using SimpleJSON;
+using System.Net;
+using XUnity.AutoTranslator.LlmTranslators.Behavior;
+using XUnity.AutoTranslator.LlmTranslators.Config;
+using XUnity.AutoTranslator.Plugin.Core.Endpoints;
+using XUnity.AutoTranslator.Plugin.Core.Endpoints.Http;
+using XUnity.AutoTranslator.Plugin.Core.Web;
+
+public class LmStudioTranslatorEndpoint : HttpEndpoint
+{
+    public override string Id => "LmStudioTranslate";
+    public override string FriendlyName => "LM Studio Translate";
+    public override int MaxTranslationsPerRequest => 1;
+
+    // Local models can saturate quickly; keep this closer to Ollama's default.
+    public override int MaxConcurrency => 5;
+
+    private LlmConfig _config = new();
+
+    public override void Initialize(IInitializationContext context)
+    {
+        string folder = Configuration.CalculateConfigFolder();
+        var file = Path.Combine(folder, "LmStudio.yaml");
+        _config = Configuration.GetConfiguration(file);
+        Configuration.LoadGlossary(_config, "LmStudio-Glossary.yaml");
+
+        // Remove artificial delays
+        context.SetTranslationDelay(0.1f);
+        context.DisableSpamChecks();
+
+        if (string.IsNullOrEmpty(_config.ApiKey) && _config.ApiKeyRequired)
+            throw new Exception("The endpoint requires an API key which has not been provided.");
+    }
+
+    public override void OnCreateRequest(IHttpRequestCreationContext context)
+    {
+        var requestData = BaseEndpointBehavior.GetRequestData(_config, context.UntranslatedText);
+
+        var request = new XUnityWebRequest("POST", _config.Url, requestData);
+        request.Headers[HttpRequestHeader.ContentType] = "application/json";
+
+        if (_config.ApiKeyRequired)
+            request.Headers[HttpRequestHeader.Authorization] = $"Bearer {_config.ApiKey}";
+
+        context.Complete(request);
+    }
+
+    public override void OnExtractTranslation(IHttpTranslationExtractionContext context)
+    {
+        var data = context.Response.Data;
+
+        var jsonResponse = JSON.Parse(data);
+        var result = jsonResponse["choices"]?[0]?["message"]?["content"]?.ToString() ?? string.Empty;
+        result = BaseEndpointBehavior.ValidateAndCleanupTranslation(context.UntranslatedText, result, _config);
+
+        if (MaxTranslationsPerRequest == 1)
+            context.Complete(result);
+    }
+}

--- a/XUnity.AutoTranslator.LlmTranslators/SampleConfig/LmStudio-Glossary.example.yaml
+++ b/XUnity.AutoTranslator.LlmTranslators/SampleConfig/LmStudio-Glossary.example.yaml
@@ -1,0 +1,19 @@
+# Copy this file to LmStudio-Glossary.yaml when using LM Studio glossary terms.
+- raw: 先輩
+  result: 선배
+  transliteration: senpai
+  context: Character relationship title
+  checkForHallucination: true
+  checkForMistranslation: true
+
+- raw: 魔王
+  result: 마왕
+  context: Fantasy title
+  checkForHallucination: true
+  checkForMistranslation: true
+
+- raw: HP
+  result: HP
+  context: Game stat label; keep unchanged
+  checkForHallucination: true
+  checkForMistranslation: true

--- a/XUnity.AutoTranslator.LlmTranslators/SampleConfig/LmStudio-Korean.example.yaml
+++ b/XUnity.AutoTranslator.LlmTranslators/SampleConfig/LmStudio-Korean.example.yaml
@@ -1,0 +1,28 @@
+# Copy this file to LmStudio.yaml when using LM Studio for Korean game translation.
+apiKey: "None"
+apiKeyRequired: false
+url: "http://localhost:1234/v1/chat/completions"
+model: "local-model-id"
+modelParams:
+  temperature: 0.15
+  max_tokens: 2048
+  top_p: 0.9
+  frequency_penalty: 0
+  presence_penalty: 0
+systemPrompt: |
+  You are translating game UI and dialogue into Korean.
+
+  Rules:
+  - Translate the source text into fluent Korean.
+  - Keep the original meaning, tone, and speaker intent.
+  - Preserve character names unless a glossary entry specifies otherwise.
+  - Preserve placeholders, variables, rich-text tags, escaped characters, and line breaks.
+  - Preserve strings such as {0}, {name}, %s, \n, <color=...>, </color>, <b>, </b>.
+  - Do not add explanations, notes, markdown, or quotation marks.
+  - If the source is already Korean, return it unchanged.
+  - Use glossary translations exactly when a matching source term appears.
+glossaryPrompt: |
+  # Glossary for Consistent Translations
+  The following terms have fixed translations.
+  Use them exactly when the source text contains the matching term.
+  ## Terms

--- a/XUnity.AutoTranslator.LlmTranslators/SampleConfig/LmStudio.yaml
+++ b/XUnity.AutoTranslator.LlmTranslators/SampleConfig/LmStudio.yaml
@@ -1,0 +1,58 @@
+apiKey: "None"
+apiKeyRequired: false
+url: "http://localhost:1234/v1/chat/completions"
+model: "model-identifier"
+modelParams:
+  temperature: 0.2
+  max_tokens: 4096
+  top_p: 0.9
+  top_k: 40
+  frequency_penalty: 0
+  presence_penalty: 0
+systemPrompt: |
+  Your task is to accurately translate Chinese strings provided into fluent English, maintaining the original tone and meaning without adding explanations or embellishments.
+
+  #### Guidelines:
+
+  **Output**
+  - Do not include additional HTML or markdown.
+
+  **Gender-Neutral Language:**
+  - Default to gender-neutral language and pronouns ("they/them"), unless specified by the text.
+
+  **Character References:**
+  - Refer to characters by their names or roles, avoiding gendered descriptors.
+  - Use gender-specific terms only if clearly identified in the text or necessary for clarity.
+
+  **Names:**
+  - Use Pinyin for Chinese names.
+
+  **Nicknames:**
+  - Translate into culturally appropriate English equivalents, maintaining meaning and sentiment.
+
+  **Title Conversion:**
+  - Convert titles such as "Doctor," "Lord," or "Master" to their English equivalents.
+  - Precede names with these titles (e.g., "Brother Li").
+  - Use glossary terms for titles as provided, with flexible capitalization but no changes to wording based on context
+  - Preserve the intended meaning and connotations of each title.
+
+  **Cultural Sensitivity:**
+  - Incorporate relevant Wuxia or traditional terms as needed.
+
+  **Idioms:**
+  - Convey the meaning, cultural context, and implications in English.
+  - Avoid direct transliteration; use literal translations within the text to maintain intended message and tone.
+
+  **Contextual Adaptations:**
+  - Resolve ambiguities using broader context for clarity.
+  - Select translations fitting the context and guidelines.
+
+  **Language Refinement:**
+  - Ensure clarity and accuracy with minimal grammatical changes.
+
+  **Capitalization:**
+  - Follow standard English grammar rules.
+glossaryPrompt: |
+  #Glossary for Consistent Translations
+  Prioritise and use the translation when an exact match with the original text is found.
+  ## Terms

--- a/XUnity.AutoTranslator.LlmTranslators/XUnity.AutoTranslator.LlmTranslators.csproj
+++ b/XUnity.AutoTranslator.LlmTranslators/XUnity.AutoTranslator.LlmTranslators.csproj
@@ -9,6 +9,7 @@
 		<Xyzj2GameDir>G:\SteamLibrary\steamapps\common\下一站江湖Ⅱ\下一站江湖Ⅱ\下一站江湖Ⅱ_Data\Managed\Translators</Xyzj2GameDir>
 		<LoMGameDir>C:\Program Files (x86)\Steam\steamapps\common\LegendOfMortal\Mortal_Data\Managed\Translators</LoMGameDir>
 		<BaseFolder>\..\..\..\</BaseFolder>
+		<DeployToGameDirs>false</DeployToGameDirs>
 		<Configurations>Debug;Release</Configurations>
 		<UserSecretsId>f11951a3-bacd-43f2-a9fa-0187cf947674</UserSecretsId>
 	</PropertyGroup>
@@ -30,31 +31,28 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" PrivateAssets="All" />
+		<PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.45" PrivateAssets="All" />
 	</ItemGroup>
 
-	<Target Name="ILRepack" AfterTargets="Build" Condition="$(Configuration) == 'Release'">
+	<Target Name="PostBuild" AfterTargets="ILRepacker" Condition="$(Configuration) == 'Release'">
 		<PropertyGroup>
-			<WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(TargetFramework)</WorkingDirectory>
+			<ReleaseFolder>$(MSBuildThisFileDirectory)..\Release\</ReleaseFolder>
+			<ReleaseTranslatorsFolder>$(ReleaseFolder)Translators\</ReleaseTranslatorsFolder>
+			<ReleaseSampleConfigFolder>$(ReleaseFolder)SampleConfig\</ReleaseSampleConfigFolder>
 		</PropertyGroup>
+
 		<ItemGroup>
-			<InputAssemblies Include="YamlDotNet.dll" />
+			<SampleConfigFiles Include="$(MSBuildThisFileDirectory)SampleConfig\**\*" />
 		</ItemGroup>
-		
-		<!-- Log message for merging assemblies -->
-		<Message Text="MERGING: @(InputAssemblies->'%(Filename)') into $(OutputAssembly)" Importance="High" />
 
-		<!-- ILRepack task to merge assemblies -->
-		<ILRepack OutputType="$(OutputType)" MainAssembly="$(AssemblyName).dll" OutputAssembly="$(AssemblyName).dll" InputAssemblies="@(InputAssemblies)" InternalizeExcludeAssemblies="@(InternalizeExcludeAssemblies)" WorkingDirectory="$(WorkingDirectory)" />
-	</Target>
+		<MakeDir Directories="$(ReleaseTranslatorsFolder);$(ReleaseSampleConfigFolder)" />
+		<Copy SourceFiles="$(TargetPath)" DestinationFolder="$(ReleaseTranslatorsFolder)" />
+		<Copy SourceFiles="@(SampleConfigFiles)" DestinationFiles="@(SampleConfigFiles->'$(ReleaseSampleConfigFolder)%(RecursiveDir)%(Filename)%(Extension)')" />
 
-	<Target Name="PostBuild" AfterTargets="ILRepack" Condition="$(Configuration) == 'Release'">
-		<Exec Command="XCOPY /Y /I &quot;$(TargetDir)$(TargetName)$(TargetExt)&quot; &quot;$(PoKGameDir)&quot;" />
-		<Exec Command="XCOPY /Y /I &quot;$(TargetDir)$(TargetName)$(TargetExt)&quot; &quot;$(Xyzj2GameDir)&quot;" />
-		<Exec Command="XCOPY /Y /I &quot;$(TargetDir)$(TargetName)$(TargetExt)&quot; &quot;$(LoMGameDir)&quot;" />
-
-		<Exec Command="XCOPY /Y /I &quot;$(TargetDir)$(TargetName)$(TargetExt)&quot; &quot;$(TargetDir)$(BaseFolder)\Release&quot;" />
-		<Exec Command="XCOPY /Y /I &quot;$(TargetDir)$(BaseFolder)\SampleConfig&quot; &quot;$(TargetDir)$(BaseFolder)\Release&quot;" />
+		<MakeDir Directories="$(PoKGameDir);$(Xyzj2GameDir);$(LoMGameDir)" Condition="'$(DeployToGameDirs)' == 'true'" />
+		<Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PoKGameDir)" Condition="'$(DeployToGameDirs)' == 'true'" />
+		<Copy SourceFiles="$(TargetPath)" DestinationFolder="$(Xyzj2GameDir)" Condition="'$(DeployToGameDirs)' == 'true'" />
+		<Copy SourceFiles="$(TargetPath)" DestinationFolder="$(LoMGameDir)" Condition="'$(DeployToGameDirs)' == 'true'" />
 	</Target>
 
 </Project>

--- a/XUnity.AutoTranslator.LlmTranslators/XUnity.AutoTranslator.LlmTranslators.csproj
+++ b/XUnity.AutoTranslator.LlmTranslators/XUnity.AutoTranslator.LlmTranslators.csproj
@@ -5,6 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PoKGameDir>C:\Program Files (x86)\Steam\steamapps\common\The road of Jianghu\daojianjianghulu_Data\Managed\Translators\</PoKGameDir>
 		<Xyzj2GameDir>G:\SteamLibrary\steamapps\common\下一站江湖Ⅱ\下一站江湖Ⅱ\下一站江湖Ⅱ_Data\Managed\Translators</Xyzj2GameDir>
 		<LoMGameDir>C:\Program Files (x86)\Steam\steamapps\common\LegendOfMortal\Mortal_Data\Managed\Translators</LoMGameDir>

--- a/XUnity.AutoTranslator.LlmTranslators/XUnity.AutoTranslator.LlmTranslators.csproj
+++ b/XUnity.AutoTranslator.LlmTranslators/XUnity.AutoTranslator.LlmTranslators.csproj
@@ -28,7 +28,7 @@
 	</ItemGroup>
  
 	<ItemGroup>
-		<PackageReference Include="YamlDotNet" Version="4.2.1" />
+		<PackageReference Include="YamlDotNet" Version="5.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/docs/BUILD_AND_YAML_EXAMPLES.ko.md
+++ b/docs/BUILD_AND_YAML_EXAMPLES.ko.md
@@ -1,0 +1,279 @@
+# 빌드 및 YAML 작성 예시
+
+이 프로젝트는 Unity 프로젝트가 아니라 **XUnity.AutoTranslator용 번역기 DLL 확장**입니다. 빌드 결과물은 게임의 XUnity.AutoTranslator `Translators` 폴더에 넣어 사용하는 `XUnity.AutoTranslator.LlmTranslators.dll`입니다.
+
+## 1. 빌드 전제
+
+필요한 항목:
+
+- .NET SDK
+- 저장소의 `libs/` 폴더에 포함된 XUnity.AutoTranslator 참조 DLL
+- LM Studio를 사용할 경우 로컬 서버 실행
+
+현재 프로젝트는 Unity/XUnity.AutoTranslator 호환성을 위해 `net45`를 대상으로 합니다.
+
+`mise`를 사용하는 경우 저장소 루트의 `mise.toml`에 .NET SDK와 작업이 명시되어 있습니다.
+
+```bash
+mise install
+mise run build
+mise run test
+```
+
+## 2. Release 빌드
+
+저장소 루트에서 실행합니다.
+
+```bash
+dotnet restore XUnity.AutoTranslate.LlmTranslators.sln
+dotnet build XUnity.AutoTranslate.LlmTranslators.sln -c Release
+```
+
+Release 빌드 후 결과물은 다음 위치에 복사됩니다.
+
+```text
+Release/
+  Translators/
+    XUnity.AutoTranslator.LlmTranslators.dll
+  SampleConfig/
+    Config.ini
+    LmStudio.yaml
+    Ollama.yaml
+    OpenAi.yaml
+```
+
+## 3. 테스트
+
+일반 테스트만 실행하려면 `PromptTests`를 제외합니다. `PromptTests`는 OpenAI, Ollama, LM Studio 같은 실제 API 또는 로컬 서버를 호출할 수 있습니다.
+
+```bash
+dotnet test XUnity.AutoTranslate.LlmTranslators.sln -c Release --no-build --filter "FullyQualifiedName!~PromptTests"
+```
+
+## 4. 게임 폴더 배치 예시
+
+BepInEx 기반 XUnity.AutoTranslator:
+
+```text
+<GameDir>/BepInEx/plugins/XUnity.AutoTranslator/Translators/
+  XUnity.AutoTranslator.LlmTranslators.dll
+
+<GameDir>/BepInEx/config/
+  Config.ini
+  LmStudio.yaml
+  LmStudio-Glossary.yaml
+```
+
+ReiPatcher 기반 XUnity.AutoTranslator:
+
+```text
+<GameDir>/<GameName>_ManagedData/Translators/
+  XUnity.AutoTranslator.LlmTranslators.dll
+
+<GameDir>/AutoTranslator/
+  Config.ini
+  LmStudio.yaml
+  LmStudio-Glossary.yaml
+```
+
+## 5. XUnity Config.ini 예시
+
+LM Studio를 사용하려면 AutoTranslator 설정에서 endpoint를 `LmStudioTranslate`로 지정합니다.
+
+```ini
+[Service]
+Endpoint=LmStudioTranslate
+FallbackEndpoint=
+
+[General]
+Language=ko
+FromLanguage=ja
+```
+
+중국어 원문을 한국어로 번역한다면 다음처럼 바꿉니다.
+
+```ini
+[General]
+Language=ko
+FromLanguage=zh
+```
+
+## 6. LM Studio 최소 YAML
+
+파일명은 반드시 `LmStudio.yaml`이어야 합니다.
+
+저장소에는 바로 복사해서 쓸 수 있는 예시도 포함되어 있습니다.
+
+```text
+XUnity.AutoTranslator.LlmTranslators/SampleConfig/LmStudio-Korean.example.yaml
+XUnity.AutoTranslator.LlmTranslators/SampleConfig/LmStudio-Glossary.example.yaml
+```
+
+```yaml
+apiKey: "None"
+apiKeyRequired: false
+url: "http://localhost:1234/v1/chat/completions"
+model: "local-model-id"
+modelParams:
+  temperature: 0.2
+  max_tokens: 1024
+  top_p: 0.9
+systemPrompt: |
+  Translate the provided Japanese game text into natural Korean.
+  Preserve names, tags, escaped characters, variables, and line breaks.
+  Output only the translated text.
+glossaryPrompt: |
+  # Glossary for Consistent Translations
+  Use the translation when an exact match appears in the source text.
+  ## Terms
+```
+
+`model` 값은 LM Studio의 local server 화면에 표시되는 모델 ID로 바꿉니다.
+
+## 7. LM Studio 권장 YAML
+
+게임 텍스트 번역용으로 조금 더 엄격하게 작성한 예시입니다.
+
+```yaml
+apiKey: "None"
+apiKeyRequired: false
+url: "http://localhost:1234/v1/chat/completions"
+model: "qwen3-8b"
+modelParams:
+  temperature: 0.15
+  max_tokens: 2048
+  top_p: 0.9
+  frequency_penalty: 0
+  presence_penalty: 0
+systemPrompt: |
+  You are translating game UI and dialogue into Korean.
+
+  Rules:
+  - Translate the source text into fluent Korean.
+  - Keep the original meaning, tone, and speaker intent.
+  - Preserve placeholders, variables, rich-text tags, escaped characters, and line breaks.
+  - Preserve strings such as {0}, {name}, %s, \n, <color=...>, </color>, <b>, </b>.
+  - Do not add explanations, notes, markdown, or quotation marks.
+  - If the source is already Korean, return it unchanged.
+  - Use the glossary exactly when a matching source term appears.
+glossaryPrompt: |
+  # Glossary for Consistent Translations
+  The following terms have fixed translations.
+  Use them exactly when the source text contains the matching term.
+  ## Terms
+```
+
+## 8. OpenAI 호환 서버 YAML
+
+LM Studio 외에도 OpenAI 호환 API 서버라면 같은 응답 형식(`choices[0].message.content`)을 쓰는 경우 `LmStudioTranslate`로 붙일 수 있습니다.
+
+```yaml
+apiKey: "your-api-key"
+apiKeyRequired: true
+url: "https://example.com/v1/chat/completions"
+model: "model-name"
+modelParams:
+  temperature: 0.2
+  max_tokens: 2048
+  top_p: 0.9
+systemPrompt: |
+  Translate Simplified Chinese game text into Korean.
+  Preserve variables, tags, escaped characters, and line breaks.
+  Output only the translation.
+glossaryPrompt: |
+  # Glossary for Consistent Translations
+  Use the translation when an exact match appears in the source text.
+  ## Terms
+```
+
+로컬 LM Studio처럼 API 키가 필요 없는 서버는 다음처럼 둡니다.
+
+```yaml
+apiKey: "None"
+apiKeyRequired: false
+```
+
+## 9. Ollama YAML 예시
+
+Ollama endpoint를 사용할 경우 파일명은 `Ollama.yaml`, endpoint는 `OllamaTranslate`입니다.
+
+```yaml
+apiKey: "None"
+apiKeyRequired: false
+url: "http://localhost:11434/api/chat"
+model: "qwen2.5:7b"
+modelParams:
+  temperature: 0.2
+  num_ctx: 8192
+  top_p: 0.9
+systemPrompt: |
+  Translate Japanese game text into Korean.
+  Preserve placeholders, tags, escaped characters, and line breaks.
+  Output only the translated text.
+glossaryPrompt: |
+  # Glossary for Consistent Translations
+  Use the translation when an exact match appears in the source text.
+  ## Terms
+```
+
+`Config.ini`에서는 다음처럼 지정합니다.
+
+```ini
+[Service]
+Endpoint=OllamaTranslate
+FallbackEndpoint=
+```
+
+## 10. Glossary YAML 예시
+
+LM Studio용 glossary 파일명은 `LmStudio-Glossary.yaml`입니다.
+
+```yaml
+- raw: 先輩
+  result: 선배
+  transliteration: senpai
+  context: Character relationship title
+  checkForHallucination: true
+  checkForMistranslation: true
+
+- raw: 魔王
+  result: 마왕
+  context: Fantasy title
+
+- raw: HP
+  result: HP
+  context: Game stat label; keep unchanged
+```
+
+코드는 원문 문자열에 `raw`가 포함되어 있을 때만 해당 glossary 항목을 프롬프트에 추가합니다.
+
+## 11. 오버라이드 파일 예시
+
+YAML을 직접 수정하지 않고 게임별 프롬프트나 키를 바꾸고 싶으면 같은 폴더에 파일을 추가합니다.
+
+```text
+LmStudio-SystemPrompt.txt
+LmStudio-GlossaryPrompt.txt
+LmStudio-ApiKey.txt
+LmStudio-Glossary.yaml
+```
+
+예를 들어 `LmStudio-SystemPrompt.txt`:
+
+```text
+Translate Japanese visual novel dialogue into natural Korean.
+Keep character names consistent.
+Preserve tags, variables, escaped sequences, and line breaks.
+Output only the Korean translation.
+```
+
+API 키가 필요한 호환 서버를 쓴다면 `LmStudio-ApiKey.txt`에 키만 넣습니다. 실제 API 키 파일은 소스 관리에 넣지 않습니다.
+
+## 12. YAML 작성 규칙
+
+- 필드명은 `apiKey`, `apiKeyRequired`, `url`, `model`, `modelParams`, `systemPrompt`, `glossaryPrompt`를 사용합니다.
+- 여러 줄 프롬프트는 `|` 블록을 사용합니다.
+- `modelParams` 아래 값은 요청 JSON의 최상위 필드로 전달됩니다.
+- LM Studio 기본 URL은 `http://localhost:1234/v1/chat/completions`입니다.
+- LM Studio 기본값은 `apiKeyRequired: false`가 적합합니다.
+- 특수문자, 콜론, URL이 들어간 값은 따옴표로 감싸는 편이 안전합니다.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,16 @@
+[tools]
+dotnet = "9"
+
+[tasks.restore]
+description = "Restore NuGet packages for the solution"
+run = "dotnet restore XUnity.AutoTranslate.LlmTranslators.sln"
+
+[tasks.build]
+description = "Build the translator plugin in Release mode"
+run = "dotnet build XUnity.AutoTranslate.LlmTranslators.sln -c Release"
+depends = ["restore"]
+
+[tasks.test]
+description = "Run non-live tests, excluding PromptTests that may call real LLM endpoints"
+run = "dotnet test XUnity.AutoTranslate.LlmTranslators.sln -c Release --no-build --filter \"FullyQualifiedName!~PromptTests\""
+depends = ["build"]


### PR DESCRIPTION
﻿## Summary

Adds an LM Studio translator endpoint for local OpenAI-compatible chat completion servers, proposes adopting the MIT License, and refreshes the README.

This lets users run translations through LM Studio's local server, which can be faster for local workflows and avoids routing requests through external hosted APIs.

## Changes

- Add `LmStudioTranslate` endpoint using LM Studio's default OpenAI-compatible `/v1/chat/completions` API.
- Add `LmStudio.yaml` sample configuration.
- Document LM Studio setup and endpoint selection in the README.
- Add config tests for the LM Studio sample.
- Fix glossary prompt override loading so `*-GlossaryPrompt.txt` updates `GlossaryPrompt`.
- Update ILRepack packaging so release builds merge only `YamlDotNet` and work with current .NET SDK tooling.
- Add a standard MIT `LICENSE` file using `joshfreitas1984 and contributors` as the copyright holder line.
- Add `PackageLicenseExpression=MIT` to the plugin project metadata.
- Refresh the README structure for supported endpoints, installation, configuration, override files, glossary behavior, prompt tuning, build/test commands, and current project notes.

## License note

The upstream repository currently does not expose a detected license through GitHub metadata. This PR proposes adopting MIT so users and contributors have explicit permission terms for use, modification, and redistribution.

## Validation

- `git diff --check`
- `dotnet restore XUnity.AutoTranslate.LlmTranslators.sln`
- `dotnet build XUnity.AutoTranslate.LlmTranslators.sln -c Debug --no-restore`
- `dotnet build XUnity.AutoTranslate.LlmTranslators.sln -c Release --no-restore`
- `dotnet test XUnity.AutoTranslate.LlmTranslators.sln -c Release --no-build --filter "FullyQualifiedName!~PromptTests"`

Note: `PromptTests` were excluded because they can call live OpenAI/Ollama/LM Studio endpoints.

Known warning: restore/build still reports the existing high-severity advisory for `YamlDotNet 4.2.1`.
